### PR TITLE
Added allowed content to addCommand() setting

### DIFF
--- a/audio/plugin.js
+++ b/audio/plugin.js
@@ -63,7 +63,9 @@ CKEDITOR.plugins.add( 'audio',
 
 		CKEDITOR.dialog.add( 'audio', this.path + 'dialogs/audio.js' );
 
-		editor.addCommand( 'Audio', new CKEDITOR.dialogCommand( 'audio' ) );
+		editor.addCommand( 'Audio', new CKEDITOR.dialogCommand( 'audio', {
+			allowedContent: 'audio[*]; source[*]'
+		}));
 		editor.ui.addButton( 'Audio',
 			{
 				label : lang.toolbar,

--- a/readme.md
+++ b/readme.md
@@ -21,4 +21,4 @@ CKEDITOR.editorConfig = function( config )
 ```
 
 ### About
-This is only an adaptation of Video plugin for CKEditor created by Alfonso Mart�nez de Lizarrondo 
+This is only an adaptation of Video plugin for CKEditor created by Alfonso Martínez de Lizarrondo

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ CKEDITOR.editorConfig = function( config )
 	config.toolbar = [ 
 	['Templates', 'Styles','Format','Font','FontSize','TextColor','BGColor','Maximize','Image'], 
 	['Source'], 
-	['Bold','Italic','Underline','Strike','-','Subscript','Superscript','-',**'audio'**], 
+	['Bold','Italic','Underline','Strike','-','Subscript','Superscript','-',**'Audio'**],
 	['Table','HorizontalRule'], 
 	['NumberedList','BulletedList','-','Outdent','Indent','Blockquote']
 	] 
@@ -21,4 +21,4 @@ CKEDITOR.editorConfig = function( config )
 ```
 
 ### About
-This is only an adaptation of Video plugin for CKEditor created by Alfonso Martínez de Lizarrondo 
+This is only an adaptation of Video plugin for CKEditor created by Alfonso Martï¿½nez de Lizarrondo 


### PR DESCRIPTION
Hey, I'm not sure how about older CKEditors (`3.*.*`) but latest 4.5.\* ignores all unknown HTML elements by default so I this plugin doesn't specify that it works with `<audio>` and `<source>` than these will be automatically removed by CKEditor.
Also, button in the toolbar seems to be case sensitive and has to match `editor.ui.addButton( 'Audio', ...)`, not plugin name.
